### PR TITLE
ADUser: Uses helper function Add-TypeAssembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@
   - Update the logic for setting the default value for the parameter
     `CommonName`. This is due to an how LCM handles parameters when a
     default value is derived from another parameter ([issue #427](https://github.com/PowerShell/ActiveDirectoryDsc/issues/427)).
+  - Now uses the helper function `Add-TypeAssembly` which have some benefit
+    instead of directly using `Add-Type`, like verbose logging ([issue #431](https://github.com/PowerShell/ActiveDirectoryDsc/issues/431)).
 - Changes to ADDomain
   - BREAKING CHANGE: Renamed the parameter `DomainAdministratorCredential`
     to `Credential` to better indicate that it is possible to impersonate

--- a/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -2377,7 +2377,9 @@ function Test-Password
 
     Write-Verbose -Message ($script:localizedData.CreatingADDomainConnection -f $DomainName)
 
-    Add-Type -AssemblyName 'System.DirectoryServices.AccountManagement'
+    $typeName = 'System.DirectoryServices.AccountManagement.PrincipalContext'
+
+    Add-TypeAssembly -AssemblyName 'System.DirectoryServices.AccountManagement' -TypeName $typeName
 
     <#
         If the domain name contains a distinguished name, set it to the fully
@@ -2397,7 +2399,7 @@ function Test-Password
             $script:localizedData.TestPasswordUsingImpersonation -f $Credential.UserName, $UserName
         )
 
-        $principalContext = New-Object -TypeName 'System.DirectoryServices.AccountManagement.PrincipalContext' -ArgumentList @(
+        $principalContext = New-Object -TypeName $typeName -ArgumentList @(
             [System.DirectoryServices.AccountManagement.ContextType]::Domain,
             $DomainName,
             $Credential.UserName,
@@ -2406,7 +2408,7 @@ function Test-Password
     }
     else
     {
-        $principalContext = New-Object -TypeName 'System.DirectoryServices.AccountManagement.PrincipalContext' -ArgumentList @(
+        $principalContext = New-Object -TypeName $typeName -ArgumentList @(
             [System.DirectoryServices.AccountManagement.ContextType]::Domain,
             $DomainName,
             $null,


### PR DESCRIPTION
#### Pull Request (PR) description
- Changes to ADUser
  - Now uses the helper function `Add-TypeAssembly` which have some benefit
    instead of directly using `Add-Type`, like verbose logging (issue #431).

#### This Pull Request (PR) fixes the following issues
- Fixes #431 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/activedirectorydsc/458)
<!-- Reviewable:end -->
