### PR TITLE
ADUser: Update the default value logic for CommonName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@
   - Now it correctly tests passwords when parameter DomainName is set to
    distinguished name and parameter Credential is used ([issue #451](https://github.com/PowerShell/ActiveDirectoryDsc/issues/451)).
   - Added integration tests ([issue #359](https://github.com/PowerShell/ActiveDirectoryDsc/issues/359)).
+  - Update the logic for setting the default value for the parameter
+    `CommonName`. This is due to an how LCM handles parameters when a
+    default value is derived from another parameter ([issue #427](https://github.com/PowerShell/ActiveDirectoryDsc/issues/427)).
 - Changes to ADDomain
   - BREAKING CHANGE: Renamed the parameter `DomainAdministratorCredential`
     to `Credential` to better indicate that it is possible to impersonate

--- a/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -460,7 +460,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateNotNull()]
         [System.String]
-        $CommonName = $UserName,
+        $CommonName,
 
         [Parameter()]
         [ValidateNotNull()]
@@ -733,6 +733,15 @@ function Get-TargetResource
         [System.String[]]
         $ProxyAddresses
     )
+
+    <#
+        This is a workaround to make the resource able to enter debug mode.
+        For more information see issue https://github.com/PowerShell/ActiveDirectoryDsc/issues/427.
+    #>
+    if (-not $PSBoundParameters.ContainsKey('CommonName'))
+    {
+        $CommonName = $UserName
+    }
 
     Assert-Module -ModuleName 'ActiveDirectory'
 
@@ -1107,7 +1116,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateNotNull()]
         [System.String]
-        $CommonName = $UserName,
+        $CommonName,
 
         [Parameter()]
         [ValidateNotNull()]
@@ -1380,6 +1389,15 @@ function Test-TargetResource
         [System.String[]]
         $ProxyAddresses
     )
+
+    <#
+        This is a workaround to make the resource able to enter debug mode.
+        For more information see issue https://github.com/PowerShell/ActiveDirectoryDsc/issues/427.
+    #>
+    if (-not $PSBoundParameters.ContainsKey('CommonName'))
+    {
+        $CommonName = $UserName
+    }
 
     Assert-Parameters @PSBoundParameters
 
@@ -1723,7 +1741,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateNotNull()]
         [System.String]
-        $CommonName = $UserName,
+        $CommonName,
 
         [Parameter()]
         [ValidateNotNull()]
@@ -1996,6 +2014,15 @@ function Set-TargetResource
         [System.String[]]
         $ProxyAddresses
     )
+
+    <#
+        This is a workaround to make the resource able to enter debug mode.
+        For more information see issue https://github.com/PowerShell/ActiveDirectoryDsc/issues/427.
+    #>
+    if (-not $PSBoundParameters.ContainsKey('CommonName'))
+    {
+        $CommonName = $UserName
+    }
 
     Assert-Parameters @PSBoundParameters
 


### PR DESCRIPTION
#### Pull Request (PR) description
- Changes to ADUser 
  - Update the logic for setting the default value for the parameter
    `CommonName`. This is due to an how LCM handles parameters when a
    default value is derived from another parameter (issue #427).

#### This Pull Request (PR) fixes the following issues
- Fixes #427 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/activedirectorydsc/460)
<!-- Reviewable:end -->
