### PR TITLE
ADUser: Remove unused non-mandatory parameters from the Get-TargetResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@
     domain name (FQDN) of the forest that the domain belongs to.
   - Added read-only property `DomainExist` that will return `$true` if
     the domain was found, or `$false` if it was not.
+- Changes to ADUser
+  - Remove unused non-mandatory parameters from the Get-TargetResource ([issue #293](https://github.com/PowerShell/ActiveDirectoryDsc/issues/293)).
 
 ## 4.0.0.0
 

--- a/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -2070,7 +2070,7 @@ function Get-MD5HashString
         $md5 = [System.Security.Cryptography.MD5]::Create()
         $hashBytes = $md5.ComputeHash($Bytes)
 
-        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-', '')
+        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-','')
     }
 
     return $md5ReturnValue

--- a/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -206,241 +206,12 @@ $adPropertyMap = @(
         Specifies the Security Account Manager (SAM) account name of the user
         (ldapDisplayName 'sAMAccountName').
 
-    .PARAMETER Password
-        Specifies a new password value for the account.
-
-    .PARAMETER Ensure
-        Specifies whether the user account should be present or absent. Default
-        value is 'Present'.
-
-    .PARAMETER CommonName
-        Specifies the common name assigned to the user account (ldapDisplayName
-        'cn'). If not specified the default value will be the same value
-        provided in parameter UserName.
-
-    .PARAMETER UserPrincipalName
-        Specifies the User Principal Name (UPN) assigned to the user account
-        (ldapDisplayName 'userPrincipalName').
-
-    .PARAMETER DisplayName
-        Specifies the display name of the object (ldapDisplayName
-        'displayName').
-
-    .PARAMETER Path
-        Specifies the X.500 path of the Organizational Unit (OU) or container
-        where the new object is created.
-
-    .PARAMETER GivenName
-        Specifies the user's given name (ldapDisplayName 'givenName').
-
-    .PARAMETER Initials
-        Specifies the initials that represent part of a user's name
-        (ldapDisplayName 'initials').
-
-    .PARAMETER Surname
-        Specifies the user's last name or surname (ldapDisplayName 'sn').
-
-    .PARAMETER Description
-        Specifies a description of the object (ldapDisplayName 'description').
-
-    .PARAMETER StreetAddress
-        Specifies the user's street address (ldapDisplayName 'streetAddress').
-
-    .PARAMETER POBox
-        Specifies the user's post office box number (ldapDisplayName
-        'postOfficeBox').
-
-    .PARAMETER City
-        Specifies the user's town or city (ldapDisplayName 'l').
-
-    .PARAMETER State
-        Specifies the user's or Organizational Unit's state or province
-        (ldapDisplayName 'st').
-
-    .PARAMETER PostalCode
-        Specifies the user's postal code or zip code (ldapDisplayName
-        'postalCode').
-
-    .PARAMETER Country
-        Specifies the country or region code for the user's language of choice
-        (ldapDisplayName 'c').
-
-    .PARAMETER Department
-        Specifies the user's department (ldapDisplayName 'department').
-
-    .PARAMETER Division
-        Specifies the user's division (ldapDisplayName 'division').
-
-    .PARAMETER Company
-        Specifies the user's company (ldapDisplayName 'company').
-
-    .PARAMETER Office
-        Specifies the location of the user's office or place of business
-        (ldapDisplayName 'physicalDeliveryOfficeName').
-
-    .PARAMETER JobTitle
-        Specifies the user's title (ldapDisplayName 'title').
-
-    .PARAMETER EmailAddress
-        Specifies the user's e-mail address (ldapDisplayName 'mail').
-
-    .PARAMETER EmployeeID
-        Specifies the user's employee ID (ldapDisplayName 'employeeID').
-
-    .PARAMETER EmployeeNumber
-        Specifies the user's employee number (ldapDisplayName 'employeeNumber').
-
-    .PARAMETER HomeDirectory
-        Specifies a user's home directory path (ldapDisplayName
-        'homeDirectory').
-
-    .PARAMETER HomeDrive
-        Specifies a drive that is associated with the UNC path defined by the
-        HomeDirectory property (ldapDisplayName 'homeDrive').
-
-    .PARAMETER HomePage
-        Specifies the URL of the home page of the object (ldapDisplayName
-        'wWWHomePage').
-
-    .PARAMETER ProfilePath
-        Specifies a path to the user's profile (ldapDisplayName 'profilePath').
-
-    .PARAMETER LogonScript
-        Specifies a path to the user's log on script (ldapDisplayName
-        'scriptPath').
-
-    .PARAMETER Notes
-        Specifies the notes attached to the user's accoutn (ldapDisplayName
-        'info').
-
-    .PARAMETER OfficePhone
-        Specifies the user's office telephone number (ldapDisplayName
-        'telephoneNumber').
-
-    .PARAMETER MobilePhone
-        Specifies the user's mobile phone number (ldapDisplayName 'mobile').
-
-    .PARAMETER Fax
-        Specifies the user's fax phone number (ldapDisplayName
-        'facsimileTelephoneNumber').
-
-    .PARAMETER HomePhone
-        Specifies the user's home telephone number (ldapDisplayName
-        'homePhone').
-
-    .PARAMETER Pager
-        Specifies the user's pager number (ldapDisplayName 'pager').
-
-    .PARAMETER IPPhone
-        Specifies the user's IP telephony phone number (ldapDisplayName
-        'ipPhone').
-
-    .PARAMETER Manager
-        Specifies the user's manager specified as a Distinguished Name
-        (ldapDisplayName 'manager').
-
-    .PARAMETER LogonWorkstations
-        Specifies the computers that the user can access. To specify more than
-        one computer, create a single comma-separated list. You can identify a
-        computer by using the Security Account Manager (SAM) account name
-        (sAMAccountName) or the DNS host name of the computer. The SAM account
-        name is the same as the NetBIOS name of the computer. The LDAP display
-        name (ldapDisplayName) for this property is userWorkStations.
-
-    .PARAMETER Organization
-        Specifies the user's organization. This parameter sets the Organization
-        property of a user object. The LDAP display name (ldapDisplayName) of
-        this property is 'o'.
-
-    .PARAMETER OtherName
-        Specifies a name in addition to a user's given name and surname, such as
-        the user's middle name. This parameter sets the OtherName property of a
-        user object. The LDAP display name (ldapDisplayName) of this property is
-        'middleName'.
-
-    .PARAMETER Enabled
-        Specifies if the account is enabled. Default value is $true.
-
-    .PARAMETER CannotChangePassword
-        Specifies whether the account password can be changed.
-
-    .PARAMETER ChangePasswordAtLogon
-        Specifies whether the account password must be changed during the next
-        logon attempt. This will only be enabled when the user is initially
-        created. This parameter cannot be set to $true if the parameter
-        PasswordNeverExpires is also set to $true.
-
-    .PARAMETER PasswordNeverExpires
-        Specifies whether the password of an account can expire.
-
-    .PARAMETER TrustedForDelegation
-        Specifies whether an account is trusted for Kerberos delegation. Default
-        value is $false.
-
-    .PARAMETER AccountNotDelegated
-        Indicates whether the security context of the user is delegated to a
-        service.  When this parameter is set to true, the security context of
-        the account is not delegated to a service even when the service account
-        is set as trusted for Kerberos delegation. This parameter sets the
-        AccountNotDelegated property for an Active Directory account. This
-        parameter also sets the ADS_UF_NOT_DELEGATED flag of the Active
-        Directory User Account Control (UAC) attribute.
-
-    .PARAMETER AllowReversiblePasswordEncryption
-        Indicates whether reversible password encryption is allowed for the
-        account. This parameter sets the AllowReversiblePasswordEncryption
-        property of the account. This parameter also sets the
-        ADS_UF_ENCRYPTED_TEXT_PASSWORD_ALLOWED flag of the Active Directory User
-        Account Control (UAC) attribute.
-
-    .PARAMETER CompoundIdentitySupported
-        Specifies whether an account supports Kerberos service tickets which
-        includes the authorization data for the user's device. This value sets
-        the compound identity supported flag of the Active Directory
-        msDS-SupportedEncryptionTypes attribute.
-
-    .PARAMETER PasswordNotRequired
-        Specifies whether the account requires a password. A password is not
-        required for a new account. This parameter sets the PasswordNotRequired
-        property of an account object.
-
-    .PARAMETER SmartcardLogonRequired
-        Specifies whether a smart card is required to logon. This parameter sets
-        the SmartCardLoginRequired property for a user object. This parameter
-        also sets the ADS_UF_SMARTCARD_REQUIRED flag of the Active Directory
-        User Account Control attribute.
-
     .PARAMETER DomainController
         Specifies the Active Directory Domain Services instance to use to
         perform the task.
 
     .PARAMETER Credential
         Specifies the user account credentials to use to perform this task.
-
-    .PARAMETER PasswordAuthentication
-        Specifies the authentication context type used when testing passwords.
-        Default value is 'Default'.
-
-    .PARAMETER PasswordNeverResets
-        Specifies whether existing user's password should be reset. Default
-        value is $false.
-
-    .PARAMETER RestoreFromRecycleBin
-        Try to restore the user object from the recycle bin before creating a
-        new one.
-
-    .PARAMETER ServicePrincipalNames
-        Specifies the service principal names for the user account.
-
-    .PARAMETER ProxyAddresses
-        Specifies the proxy addresses for the user account.
-
-    .PARAMETER ThumbnailPhoto
-        Specifies the thumbnail photo to be used for the user object. Can be set
-        either to a path pointing to a .jpg-file, or to a Base64-encoded jpeg
-        image. If set to an empty string ('') the current thumbnail photo will be
-        removed. The property ThumbnailPhoto will always return the image as a
-        Base64-encoded string even if the configuration specified a file path.
 #>
 function Get-TargetResource
 {
@@ -459,11 +230,6 @@ function Get-TargetResource
         [Parameter()]
         [ValidateNotNull()]
         [System.String]
-        $CommonName,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
         $DomainController,
 
         [Parameter()]
@@ -472,15 +238,6 @@ function Get-TargetResource
         [System.Management.Automation.CredentialAttribute()]
         $Credential
     )
-
-    <#
-        This is a workaround to make the resource able to enter debug mode.
-        For more information see issue https://github.com/PowerShell/ActiveDirectoryDsc/issues/427.
-    #>
-    if (-not $PSBoundParameters.ContainsKey('CommonName'))
-    {
-        $CommonName = $UserName
-    }
 
     Assert-Module -ModuleName 'ActiveDirectory'
 
@@ -509,13 +266,13 @@ function Get-TargetResource
 
         Write-Verbose -Message ($script:localizedData.ADUserIsPresent -f $UserName, $DomainName)
 
-        $Ensure = 'Present'
+        $ensure = 'Present'
     }
     catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException]
     {
         Write-Verbose -Message ($script:localizedData.ADUserNotPresent -f $UserName, $DomainName)
 
-        $Ensure = 'Absent'
+        $ensure = 'Absent'
     }
     catch
     {
@@ -525,10 +282,10 @@ function Get-TargetResource
 
     $targetResource = @{
         DomainName        = $DomainName
-        Password          = $Password
         UserName          = $UserName
+        Password          = $null
         DistinguishedName = $adUser.DistinguishedName; # Read-only property
-        Ensure            = $Ensure
+        Ensure            = $ensure
         DomainController  = $DomainController
     }
 
@@ -869,7 +626,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure = 'Present',
+        $ensure = 'Present',
 
         [Parameter()]
         [ValidateNotNull()]
@@ -1163,31 +920,25 @@ function Test-TargetResource
     Assert-Parameters @PSBoundParameters
 
     $getParameters = @{ }
-    if ($PSBoundParameters.ContainsKey('DomainName'))
-    {
-        $getParameters['DomainName'] = $PSBoundParameters['DomainName']
-    }
-    if ($PSBoundParameters.ContainsKey('UserName'))
-    {
-        $getParameters['UserName'] = $PSBoundParameters['UserName']
-    }
-    if ($PSBoundParameters.ContainsKey('CommonName'))
-    {
-        $getParameters['CommonName'] = $PSBoundParameters['CommonName']
-    }
+
+    $getParameters['DomainName'] = $PSBoundParameters['DomainName']
+    $getParameters['UserName'] = $PSBoundParameters['UserName']
+
     if ($PSBoundParameters.ContainsKey('DomainController'))
     {
         $getParameters['DomainController'] = $PSBoundParameters['DomainController']
     }
+
     if ($PSBoundParameters.ContainsKey('Credential'))
     {
         $getParameters['Credential'] = $PSBoundParameters['Credential']
     }
+
     $targetResource = Get-TargetResource @getParameters
 
     $isCompliant = $true
 
-    if ($Ensure -eq 'Absent')
+    if ($ensure -eq 'Absent')
     {
         if ($targetResource.Ensure -eq 'Present')
         {
@@ -1198,7 +949,7 @@ function Test-TargetResource
     else
     {
         # Add common name, ensure and enabled as they may not be explicitly passed and we want to enumerate them
-        $PSBoundParameters['Ensure'] = $Ensure
+        $PSBoundParameters['Ensure'] = $ensure
         $PSBoundParameters['Enabled'] = $Enabled
 
         foreach ($parameter in $PSBoundParameters.Keys)
@@ -1542,7 +1293,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure = 'Present',
+        $ensure = 'Present',
 
         [Parameter()]
         [ValidateNotNull()]
@@ -1837,34 +1588,28 @@ function Set-TargetResource
     Assert-Parameters @PSBoundParameters
 
     $getParameters = @{ }
-    if ($PSBoundParameters.ContainsKey('DomainName'))
-    {
-        $getParameters['DomainName'] = $PSBoundParameters['DomainName']
-    }
-    if ($PSBoundParameters.ContainsKey('UserName'))
-    {
-        $getParameters['UserName'] = $PSBoundParameters['UserName']
-    }
-    if ($PSBoundParameters.ContainsKey('CommonName'))
-    {
-        $getParameters['CommonName'] = $PSBoundParameters['CommonName']
-    }
+
+    $getParameters['DomainName'] = $PSBoundParameters['DomainName']
+    $getParameters['UserName'] = $PSBoundParameters['UserName']
+
     if ($PSBoundParameters.ContainsKey('DomainController'))
     {
         $getParameters['DomainController'] = $PSBoundParameters['DomainController']
     }
+
     if ($PSBoundParameters.ContainsKey('Credential'))
     {
         $getParameters['Credential'] = $PSBoundParameters['Credential']
     }
+
     $targetResource = Get-TargetResource @getParameters
 
     # Add common name, ensure and enabled as they may not be explicitly passed
-    $PSBoundParameters['Ensure'] = $Ensure
+    $PSBoundParameters['Ensure'] = $ensure
     $PSBoundParameters['Enabled'] = $Enabled
     $newADUser = $false
 
-    if ($Ensure -eq 'Present')
+    if ($ensure -eq 'Present')
     {
         if ($targetResource.Ensure -eq 'Absent')
         {
@@ -2102,7 +1847,7 @@ function Set-TargetResource
             Rename-ADObject @renameAdObjectParameters -NewName $PSBoundParameters.CommonName
         }
     }
-    elseif (($Ensure -eq 'Absent') -and ($targetResource.Ensure -eq 'Present'))
+    elseif (($ensure -eq 'Absent') -and ($targetResource.Ensure -eq 'Present'))
     {
         # User exists and needs removing
         Write-Verbose ($script:localizedData.RemovingADUser -f $UserName)
@@ -2329,7 +2074,7 @@ function Get-MD5HashString
         $md5 = [System.Security.Cryptography.MD5]::Create()
         $hashBytes = $md5.ComputeHash($Bytes)
 
-        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-','')
+        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-', '')
     }
 
     return $md5ReturnValue

--- a/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -928,10 +928,12 @@ function Test-TargetResource
     {
         $getParameters['DomainController'] = $PSBoundParameters['DomainController']
     }
+
     if ($PSBoundParameters.ContainsKey('Credential'))
     {
         $getParameters['Credential'] = $PSBoundParameters['Credential']
     }
+
     $targetResource = Get-TargetResource @getParameters
 
     $isCompliant = $true
@@ -1594,10 +1596,12 @@ function Set-TargetResource
     {
         $getParameters['DomainController'] = $PSBoundParameters['DomainController']
     }
+
     if ($PSBoundParameters.ContainsKey('Credential'))
     {
         $getParameters['Credential'] = $PSBoundParameters['Credential']
     }
+
     $targetResource = Get-TargetResource @getParameters
 
     # Add common name, ensure and enabled as they may not be explicitly passed
@@ -2070,7 +2074,7 @@ function Get-MD5HashString
         $md5 = [System.Security.Cryptography.MD5]::Create()
         $hashBytes = $md5.ComputeHash($Bytes)
 
-        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-','')
+        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-', '')
     }
 
     return $md5ReturnValue

--- a/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -143,7 +143,7 @@ $adPropertyMap = @(
         Parameter = 'OtherName'
     }
     @{
-        Parameter = 'ThumbnailPhoto'
+        Parameter  = 'ThumbnailPhoto'
         ADProperty = 'thumbnailPhoto'
     }
     @{
@@ -458,254 +458,8 @@ function Get-TargetResource
 
         [Parameter()]
         [ValidateNotNull()]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.CredentialAttribute()]
-        $Password,
-
-        [Parameter()]
-        [ValidateSet('Present', 'Absent')]
-        [System.String]
-        $Ensure = 'Present',
-
-        [Parameter()]
-        [ValidateNotNull()]
         [System.String]
         $CommonName,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $UserPrincipalName,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $DisplayName,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Path,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $GivenName,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Initials,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Surname,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Description,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $StreetAddress,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $POBox,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $City,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $State,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $PostalCode,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Country,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Department,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Division,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Company,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Office,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $JobTitle,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $EmailAddress,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $EmployeeID,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $EmployeeNumber,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $HomeDirectory,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $HomeDrive,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $HomePage,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $ProfilePath,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $LogonScript,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Notes,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $OfficePhone,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $MobilePhone,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Fax,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $HomePhone,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Pager,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $IPPhone,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Manager,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $LogonWorkstations,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $Organization,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $OtherName,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.Boolean]
-        $Enabled = $true,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.Boolean]
-        $CannotChangePassword,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.Boolean]
-        $ChangePasswordAtLogon,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.Boolean]
-        $PasswordNeverExpires,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.Boolean]
-        $TrustedForDelegation,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.Boolean]
-        $AccountNotDelegated,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.Boolean]
-        $AllowReversiblePasswordEncryption,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.Boolean]
-        $CompoundIdentitySupported,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.Boolean]
-        $PasswordNotRequired,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.Boolean]
-        $SmartcardLogonRequired,
 
         [Parameter()]
         [ValidateNotNull()]
@@ -716,36 +470,7 @@ function Get-TargetResource
         [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.CredentialAttribute()]
-        $Credential,
-
-        [Parameter()]
-        [ValidateSet('Default', 'Negotiate')]
-        [System.String]
-        $PasswordAuthentication = 'Default',
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.Boolean]
-        $PasswordNeverResets = $false,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.Boolean]
-        $RestoreFromRecycleBin,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String[]]
-        $ServicePrincipalNames,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String[]]
-        $ProxyAddresses,
-
-        [Parameter()]
-        [System.String]
-        $ThumbnailPhoto
+        $Credential
     )
 
     <#
@@ -1435,10 +1160,30 @@ function Test-TargetResource
     {
         $CommonName = $UserName
     }
-
     Assert-Parameters @PSBoundParameters
 
-    $targetResource = Get-TargetResource @PSBoundParameters
+    $getParameters = @{ }
+    if ($PSBoundParameters.ContainsKey('DomainName'))
+    {
+        $getParameters['DomainName'] = $PSBoundParameters['DomainName']
+    }
+    if ($PSBoundParameters.ContainsKey('UserName'))
+    {
+        $getParameters['UserName'] = $PSBoundParameters['UserName']
+    }
+    if ($PSBoundParameters.ContainsKey('CommonName'))
+    {
+        $getParameters['CommonName'] = $PSBoundParameters['CommonName']
+    }
+    if ($PSBoundParameters.ContainsKey('DomainController'))
+    {
+        $getParameters['DomainController'] = $PSBoundParameters['DomainController']
+    }
+    if ($PSBoundParameters.ContainsKey('Credential'))
+    {
+        $getParameters['Credential'] = $PSBoundParameters['Credential']
+    }
+    $targetResource = Get-TargetResource @getParameters
 
     $isCompliant = $true
 
@@ -2091,7 +1836,28 @@ function Set-TargetResource
 
     Assert-Parameters @PSBoundParameters
 
-    $targetResource = Get-TargetResource @PSBoundParameters
+    $getParameters = @{ }
+    if ($PSBoundParameters.ContainsKey('DomainName'))
+    {
+        $getParameters['DomainName'] = $PSBoundParameters['DomainName']
+    }
+    if ($PSBoundParameters.ContainsKey('UserName'))
+    {
+        $getParameters['UserName'] = $PSBoundParameters['UserName']
+    }
+    if ($PSBoundParameters.ContainsKey('CommonName'))
+    {
+        $getParameters['CommonName'] = $PSBoundParameters['CommonName']
+    }
+    if ($PSBoundParameters.ContainsKey('DomainController'))
+    {
+        $getParameters['DomainController'] = $PSBoundParameters['DomainController']
+    }
+    if ($PSBoundParameters.ContainsKey('Credential'))
+    {
+        $getParameters['Credential'] = $PSBoundParameters['Credential']
+    }
+    $targetResource = Get-TargetResource @getParameters
 
     # Add common name, ensure and enabled as they may not be explicitly passed
     $PSBoundParameters['Ensure'] = $Ensure
@@ -2131,7 +1897,7 @@ function Set-TargetResource
                 New-ADUser @newADUserParams -SamAccountName $UserName
 
                 # Now retrieve the newly created user
-                $targetResource = Get-TargetResource @PSBoundParameters
+                $targetResource = Get-TargetResource @getParameters
 
                 $newADUser = $true
             }
@@ -2152,9 +1918,9 @@ function Set-TargetResource
             {
                 # Find the associated AD property
                 $adProperty = $adPropertyMap |
-                    Where-Object -FilterScript {
-                        $_.Parameter -eq $parameter
-                    }
+                Where-Object -FilterScript {
+                    $_.Parameter -eq $parameter
+                }
 
                 if ($parameter -eq 'Path' -and ($PSBoundParameters.Path -ne $targetResource.Path))
                 {
@@ -2563,7 +2329,7 @@ function Get-MD5HashString
         $md5 = [System.Security.Cryptography.MD5]::Create()
         $hashBytes = $md5.ComputeHash($Bytes)
 
-        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-','')
+        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-', '')
     }
 
     return $md5ReturnValue
@@ -2660,11 +2426,11 @@ function Compare-ThumbnailPhoto
         compare empty values correctly.
     #>
     if ($desiredThumbnailPhotoHash -eq $CurrentThumbnailPhotoHash `
-        -or (
+            -or (
             [System.String]::IsNullOrEmpty($desiredThumbnailPhotoHash) `
-            -and [System.String]::IsNullOrEmpty($CurrentThumbnailPhotoHash)
-            )
+                -and [System.String]::IsNullOrEmpty($CurrentThumbnailPhotoHash)
         )
+    )
     {
         $returnValue = $null
     }

--- a/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -2329,7 +2329,7 @@ function Get-MD5HashString
         $md5 = [System.Security.Cryptography.MD5]::Create()
         $hashBytes = $md5.ComputeHash($Bytes)
 
-        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-', '')
+        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-','')
     }
 
     return $md5ReturnValue

--- a/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -206,12 +206,241 @@ $adPropertyMap = @(
         Specifies the Security Account Manager (SAM) account name of the user
         (ldapDisplayName 'sAMAccountName').
 
+    .PARAMETER Password
+        Specifies a new password value for the account.
+
+    .PARAMETER Ensure
+        Specifies whether the user account should be present or absent. Default
+        value is 'Present'.
+
+    .PARAMETER CommonName
+        Specifies the common name assigned to the user account (ldapDisplayName
+        'cn'). If not specified the default value will be the same value
+        provided in parameter UserName.
+
+    .PARAMETER UserPrincipalName
+        Specifies the User Principal Name (UPN) assigned to the user account
+        (ldapDisplayName 'userPrincipalName').
+
+    .PARAMETER DisplayName
+        Specifies the display name of the object (ldapDisplayName
+        'displayName').
+
+    .PARAMETER Path
+        Specifies the X.500 path of the Organizational Unit (OU) or container
+        where the new object is created.
+
+    .PARAMETER GivenName
+        Specifies the user's given name (ldapDisplayName 'givenName').
+
+    .PARAMETER Initials
+        Specifies the initials that represent part of a user's name
+        (ldapDisplayName 'initials').
+
+    .PARAMETER Surname
+        Specifies the user's last name or surname (ldapDisplayName 'sn').
+
+    .PARAMETER Description
+        Specifies a description of the object (ldapDisplayName 'description').
+
+    .PARAMETER StreetAddress
+        Specifies the user's street address (ldapDisplayName 'streetAddress').
+
+    .PARAMETER POBox
+        Specifies the user's post office box number (ldapDisplayName
+        'postOfficeBox').
+
+    .PARAMETER City
+        Specifies the user's town or city (ldapDisplayName 'l').
+
+    .PARAMETER State
+        Specifies the user's or Organizational Unit's state or province
+        (ldapDisplayName 'st').
+
+    .PARAMETER PostalCode
+        Specifies the user's postal code or zip code (ldapDisplayName
+        'postalCode').
+
+    .PARAMETER Country
+        Specifies the country or region code for the user's language of choice
+        (ldapDisplayName 'c').
+
+    .PARAMETER Department
+        Specifies the user's department (ldapDisplayName 'department').
+
+    .PARAMETER Division
+        Specifies the user's division (ldapDisplayName 'division').
+
+    .PARAMETER Company
+        Specifies the user's company (ldapDisplayName 'company').
+
+    .PARAMETER Office
+        Specifies the location of the user's office or place of business
+        (ldapDisplayName 'physicalDeliveryOfficeName').
+
+    .PARAMETER JobTitle
+        Specifies the user's title (ldapDisplayName 'title').
+
+    .PARAMETER EmailAddress
+        Specifies the user's e-mail address (ldapDisplayName 'mail').
+
+    .PARAMETER EmployeeID
+        Specifies the user's employee ID (ldapDisplayName 'employeeID').
+
+    .PARAMETER EmployeeNumber
+        Specifies the user's employee number (ldapDisplayName 'employeeNumber').
+
+    .PARAMETER HomeDirectory
+        Specifies a user's home directory path (ldapDisplayName
+        'homeDirectory').
+
+    .PARAMETER HomeDrive
+        Specifies a drive that is associated with the UNC path defined by the
+        HomeDirectory property (ldapDisplayName 'homeDrive').
+
+    .PARAMETER HomePage
+        Specifies the URL of the home page of the object (ldapDisplayName
+        'wWWHomePage').
+
+    .PARAMETER ProfilePath
+        Specifies a path to the user's profile (ldapDisplayName 'profilePath').
+
+    .PARAMETER LogonScript
+        Specifies a path to the user's log on script (ldapDisplayName
+        'scriptPath').
+
+    .PARAMETER Notes
+        Specifies the notes attached to the user's accoutn (ldapDisplayName
+        'info').
+
+    .PARAMETER OfficePhone
+        Specifies the user's office telephone number (ldapDisplayName
+        'telephoneNumber').
+
+    .PARAMETER MobilePhone
+        Specifies the user's mobile phone number (ldapDisplayName 'mobile').
+
+    .PARAMETER Fax
+        Specifies the user's fax phone number (ldapDisplayName
+        'facsimileTelephoneNumber').
+
+    .PARAMETER HomePhone
+        Specifies the user's home telephone number (ldapDisplayName
+        'homePhone').
+
+    .PARAMETER Pager
+        Specifies the user's pager number (ldapDisplayName 'pager').
+
+    .PARAMETER IPPhone
+        Specifies the user's IP telephony phone number (ldapDisplayName
+        'ipPhone').
+
+    .PARAMETER Manager
+        Specifies the user's manager specified as a Distinguished Name
+        (ldapDisplayName 'manager').
+
+    .PARAMETER LogonWorkstations
+        Specifies the computers that the user can access. To specify more than
+        one computer, create a single comma-separated list. You can identify a
+        computer by using the Security Account Manager (SAM) account name
+        (sAMAccountName) or the DNS host name of the computer. The SAM account
+        name is the same as the NetBIOS name of the computer. The LDAP display
+        name (ldapDisplayName) for this property is userWorkStations.
+
+    .PARAMETER Organization
+        Specifies the user's organization. This parameter sets the Organization
+        property of a user object. The LDAP display name (ldapDisplayName) of
+        this property is 'o'.
+
+    .PARAMETER OtherName
+        Specifies a name in addition to a user's given name and surname, such as
+        the user's middle name. This parameter sets the OtherName property of a
+        user object. The LDAP display name (ldapDisplayName) of this property is
+        'middleName'.
+
+    .PARAMETER Enabled
+        Specifies if the account is enabled. Default value is $true.
+
+    .PARAMETER CannotChangePassword
+        Specifies whether the account password can be changed.
+
+    .PARAMETER ChangePasswordAtLogon
+        Specifies whether the account password must be changed during the next
+        logon attempt. This will only be enabled when the user is initially
+        created. This parameter cannot be set to $true if the parameter
+        PasswordNeverExpires is also set to $true.
+
+    .PARAMETER PasswordNeverExpires
+        Specifies whether the password of an account can expire.
+
+    .PARAMETER TrustedForDelegation
+        Specifies whether an account is trusted for Kerberos delegation. Default
+        value is $false.
+
+    .PARAMETER AccountNotDelegated
+        Indicates whether the security context of the user is delegated to a
+        service.  When this parameter is set to true, the security context of
+        the account is not delegated to a service even when the service account
+        is set as trusted for Kerberos delegation. This parameter sets the
+        AccountNotDelegated property for an Active Directory account. This
+        parameter also sets the ADS_UF_NOT_DELEGATED flag of the Active
+        Directory User Account Control (UAC) attribute.
+
+    .PARAMETER AllowReversiblePasswordEncryption
+        Indicates whether reversible password encryption is allowed for the
+        account. This parameter sets the AllowReversiblePasswordEncryption
+        property of the account. This parameter also sets the
+        ADS_UF_ENCRYPTED_TEXT_PASSWORD_ALLOWED flag of the Active Directory User
+        Account Control (UAC) attribute.
+
+    .PARAMETER CompoundIdentitySupported
+        Specifies whether an account supports Kerberos service tickets which
+        includes the authorization data for the user's device. This value sets
+        the compound identity supported flag of the Active Directory
+        msDS-SupportedEncryptionTypes attribute.
+
+    .PARAMETER PasswordNotRequired
+        Specifies whether the account requires a password. A password is not
+        required for a new account. This parameter sets the PasswordNotRequired
+        property of an account object.
+
+    .PARAMETER SmartcardLogonRequired
+        Specifies whether a smart card is required to logon. This parameter sets
+        the SmartCardLoginRequired property for a user object. This parameter
+        also sets the ADS_UF_SMARTCARD_REQUIRED flag of the Active Directory
+        User Account Control attribute.
+
     .PARAMETER DomainController
         Specifies the Active Directory Domain Services instance to use to
         perform the task.
 
     .PARAMETER Credential
         Specifies the user account credentials to use to perform this task.
+
+    .PARAMETER PasswordAuthentication
+        Specifies the authentication context type used when testing passwords.
+        Default value is 'Default'.
+
+    .PARAMETER PasswordNeverResets
+        Specifies whether existing user's password should be reset. Default
+        value is $false.
+
+    .PARAMETER RestoreFromRecycleBin
+        Try to restore the user object from the recycle bin before creating a
+        new one.
+
+    .PARAMETER ServicePrincipalNames
+        Specifies the service principal names for the user account.
+
+    .PARAMETER ProxyAddresses
+        Specifies the proxy addresses for the user account.
+
+    .PARAMETER ThumbnailPhoto
+        Specifies the thumbnail photo to be used for the user object. Can be set
+        either to a path pointing to a .jpg-file, or to a Base64-encoded jpeg
+        image. If set to an empty string ('') the current thumbnail photo will be
+        removed. The property ThumbnailPhoto will always return the image as a
+        Base64-encoded string even if the configuration specified a file path.
 #>
 function Get-TargetResource
 {
@@ -226,6 +455,11 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $UserName,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.String]
+        $CommonName,
 
         [Parameter()]
         [ValidateNotNull()]
@@ -928,12 +1162,10 @@ function Test-TargetResource
     {
         $getParameters['DomainController'] = $PSBoundParameters['DomainController']
     }
-
     if ($PSBoundParameters.ContainsKey('Credential'))
     {
         $getParameters['Credential'] = $PSBoundParameters['Credential']
     }
-
     $targetResource = Get-TargetResource @getParameters
 
     $isCompliant = $true
@@ -1596,12 +1828,10 @@ function Set-TargetResource
     {
         $getParameters['DomainController'] = $PSBoundParameters['DomainController']
     }
-
     if ($PSBoundParameters.ContainsKey('Credential'))
     {
         $getParameters['Credential'] = $PSBoundParameters['Credential']
     }
-
     $targetResource = Get-TargetResource @getParameters
 
     # Add common name, ensure and enabled as they may not be explicitly passed

--- a/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -2304,7 +2304,7 @@ function Get-MD5HashString
         $md5 = [System.Security.Cryptography.MD5]::Create()
         $hashBytes = $md5.ComputeHash($Bytes)
 
-        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-', '')
+        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-','')
     }
 
     return $md5ReturnValue

--- a/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -919,8 +919,6 @@ function Test-TargetResource
     }
     Assert-Parameters @PSBoundParameters
 
-    $getParameters = @{ }
-
     $getParameters = @{
         DomainName = $DomainName
         UserName   = $UserName
@@ -1588,8 +1586,6 @@ function Set-TargetResource
     }
 
     Assert-Parameters @PSBoundParameters
-
-    $getParameters = @{ }
 
     $getParameters = @{
         DomainName = $DomainName

--- a/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -206,241 +206,12 @@ $adPropertyMap = @(
         Specifies the Security Account Manager (SAM) account name of the user
         (ldapDisplayName 'sAMAccountName').
 
-    .PARAMETER Password
-        Specifies a new password value for the account.
-
-    .PARAMETER Ensure
-        Specifies whether the user account should be present or absent. Default
-        value is 'Present'.
-
-    .PARAMETER CommonName
-        Specifies the common name assigned to the user account (ldapDisplayName
-        'cn'). If not specified the default value will be the same value
-        provided in parameter UserName.
-
-    .PARAMETER UserPrincipalName
-        Specifies the User Principal Name (UPN) assigned to the user account
-        (ldapDisplayName 'userPrincipalName').
-
-    .PARAMETER DisplayName
-        Specifies the display name of the object (ldapDisplayName
-        'displayName').
-
-    .PARAMETER Path
-        Specifies the X.500 path of the Organizational Unit (OU) or container
-        where the new object is created.
-
-    .PARAMETER GivenName
-        Specifies the user's given name (ldapDisplayName 'givenName').
-
-    .PARAMETER Initials
-        Specifies the initials that represent part of a user's name
-        (ldapDisplayName 'initials').
-
-    .PARAMETER Surname
-        Specifies the user's last name or surname (ldapDisplayName 'sn').
-
-    .PARAMETER Description
-        Specifies a description of the object (ldapDisplayName 'description').
-
-    .PARAMETER StreetAddress
-        Specifies the user's street address (ldapDisplayName 'streetAddress').
-
-    .PARAMETER POBox
-        Specifies the user's post office box number (ldapDisplayName
-        'postOfficeBox').
-
-    .PARAMETER City
-        Specifies the user's town or city (ldapDisplayName 'l').
-
-    .PARAMETER State
-        Specifies the user's or Organizational Unit's state or province
-        (ldapDisplayName 'st').
-
-    .PARAMETER PostalCode
-        Specifies the user's postal code or zip code (ldapDisplayName
-        'postalCode').
-
-    .PARAMETER Country
-        Specifies the country or region code for the user's language of choice
-        (ldapDisplayName 'c').
-
-    .PARAMETER Department
-        Specifies the user's department (ldapDisplayName 'department').
-
-    .PARAMETER Division
-        Specifies the user's division (ldapDisplayName 'division').
-
-    .PARAMETER Company
-        Specifies the user's company (ldapDisplayName 'company').
-
-    .PARAMETER Office
-        Specifies the location of the user's office or place of business
-        (ldapDisplayName 'physicalDeliveryOfficeName').
-
-    .PARAMETER JobTitle
-        Specifies the user's title (ldapDisplayName 'title').
-
-    .PARAMETER EmailAddress
-        Specifies the user's e-mail address (ldapDisplayName 'mail').
-
-    .PARAMETER EmployeeID
-        Specifies the user's employee ID (ldapDisplayName 'employeeID').
-
-    .PARAMETER EmployeeNumber
-        Specifies the user's employee number (ldapDisplayName 'employeeNumber').
-
-    .PARAMETER HomeDirectory
-        Specifies a user's home directory path (ldapDisplayName
-        'homeDirectory').
-
-    .PARAMETER HomeDrive
-        Specifies a drive that is associated with the UNC path defined by the
-        HomeDirectory property (ldapDisplayName 'homeDrive').
-
-    .PARAMETER HomePage
-        Specifies the URL of the home page of the object (ldapDisplayName
-        'wWWHomePage').
-
-    .PARAMETER ProfilePath
-        Specifies a path to the user's profile (ldapDisplayName 'profilePath').
-
-    .PARAMETER LogonScript
-        Specifies a path to the user's log on script (ldapDisplayName
-        'scriptPath').
-
-    .PARAMETER Notes
-        Specifies the notes attached to the user's accoutn (ldapDisplayName
-        'info').
-
-    .PARAMETER OfficePhone
-        Specifies the user's office telephone number (ldapDisplayName
-        'telephoneNumber').
-
-    .PARAMETER MobilePhone
-        Specifies the user's mobile phone number (ldapDisplayName 'mobile').
-
-    .PARAMETER Fax
-        Specifies the user's fax phone number (ldapDisplayName
-        'facsimileTelephoneNumber').
-
-    .PARAMETER HomePhone
-        Specifies the user's home telephone number (ldapDisplayName
-        'homePhone').
-
-    .PARAMETER Pager
-        Specifies the user's pager number (ldapDisplayName 'pager').
-
-    .PARAMETER IPPhone
-        Specifies the user's IP telephony phone number (ldapDisplayName
-        'ipPhone').
-
-    .PARAMETER Manager
-        Specifies the user's manager specified as a Distinguished Name
-        (ldapDisplayName 'manager').
-
-    .PARAMETER LogonWorkstations
-        Specifies the computers that the user can access. To specify more than
-        one computer, create a single comma-separated list. You can identify a
-        computer by using the Security Account Manager (SAM) account name
-        (sAMAccountName) or the DNS host name of the computer. The SAM account
-        name is the same as the NetBIOS name of the computer. The LDAP display
-        name (ldapDisplayName) for this property is userWorkStations.
-
-    .PARAMETER Organization
-        Specifies the user's organization. This parameter sets the Organization
-        property of a user object. The LDAP display name (ldapDisplayName) of
-        this property is 'o'.
-
-    .PARAMETER OtherName
-        Specifies a name in addition to a user's given name and surname, such as
-        the user's middle name. This parameter sets the OtherName property of a
-        user object. The LDAP display name (ldapDisplayName) of this property is
-        'middleName'.
-
-    .PARAMETER Enabled
-        Specifies if the account is enabled. Default value is $true.
-
-    .PARAMETER CannotChangePassword
-        Specifies whether the account password can be changed.
-
-    .PARAMETER ChangePasswordAtLogon
-        Specifies whether the account password must be changed during the next
-        logon attempt. This will only be enabled when the user is initially
-        created. This parameter cannot be set to $true if the parameter
-        PasswordNeverExpires is also set to $true.
-
-    .PARAMETER PasswordNeverExpires
-        Specifies whether the password of an account can expire.
-
-    .PARAMETER TrustedForDelegation
-        Specifies whether an account is trusted for Kerberos delegation. Default
-        value is $false.
-
-    .PARAMETER AccountNotDelegated
-        Indicates whether the security context of the user is delegated to a
-        service.  When this parameter is set to true, the security context of
-        the account is not delegated to a service even when the service account
-        is set as trusted for Kerberos delegation. This parameter sets the
-        AccountNotDelegated property for an Active Directory account. This
-        parameter also sets the ADS_UF_NOT_DELEGATED flag of the Active
-        Directory User Account Control (UAC) attribute.
-
-    .PARAMETER AllowReversiblePasswordEncryption
-        Indicates whether reversible password encryption is allowed for the
-        account. This parameter sets the AllowReversiblePasswordEncryption
-        property of the account. This parameter also sets the
-        ADS_UF_ENCRYPTED_TEXT_PASSWORD_ALLOWED flag of the Active Directory User
-        Account Control (UAC) attribute.
-
-    .PARAMETER CompoundIdentitySupported
-        Specifies whether an account supports Kerberos service tickets which
-        includes the authorization data for the user's device. This value sets
-        the compound identity supported flag of the Active Directory
-        msDS-SupportedEncryptionTypes attribute.
-
-    .PARAMETER PasswordNotRequired
-        Specifies whether the account requires a password. A password is not
-        required for a new account. This parameter sets the PasswordNotRequired
-        property of an account object.
-
-    .PARAMETER SmartcardLogonRequired
-        Specifies whether a smart card is required to logon. This parameter sets
-        the SmartCardLoginRequired property for a user object. This parameter
-        also sets the ADS_UF_SMARTCARD_REQUIRED flag of the Active Directory
-        User Account Control attribute.
-
     .PARAMETER DomainController
         Specifies the Active Directory Domain Services instance to use to
         perform the task.
 
     .PARAMETER Credential
         Specifies the user account credentials to use to perform this task.
-
-    .PARAMETER PasswordAuthentication
-        Specifies the authentication context type used when testing passwords.
-        Default value is 'Default'.
-
-    .PARAMETER PasswordNeverResets
-        Specifies whether existing user's password should be reset. Default
-        value is $false.
-
-    .PARAMETER RestoreFromRecycleBin
-        Try to restore the user object from the recycle bin before creating a
-        new one.
-
-    .PARAMETER ServicePrincipalNames
-        Specifies the service principal names for the user account.
-
-    .PARAMETER ProxyAddresses
-        Specifies the proxy addresses for the user account.
-
-    .PARAMETER ThumbnailPhoto
-        Specifies the thumbnail photo to be used for the user object. Can be set
-        either to a path pointing to a .jpg-file, or to a Base64-encoded jpeg
-        image. If set to an empty string ('') the current thumbnail photo will be
-        removed. The property ThumbnailPhoto will always return the image as a
-        Base64-encoded string even if the configuration specified a file path.
 #>
 function Get-TargetResource
 {
@@ -455,11 +226,6 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $UserName,
-
-        [Parameter()]
-        [ValidateNotNull()]
-        [System.String]
-        $CommonName,
 
         [Parameter()]
         [ValidateNotNull()]
@@ -1162,10 +928,12 @@ function Test-TargetResource
     {
         $getParameters['DomainController'] = $PSBoundParameters['DomainController']
     }
+
     if ($PSBoundParameters.ContainsKey('Credential'))
     {
         $getParameters['Credential'] = $PSBoundParameters['Credential']
     }
+
     $targetResource = Get-TargetResource @getParameters
 
     $isCompliant = $true
@@ -1828,10 +1596,12 @@ function Set-TargetResource
     {
         $getParameters['DomainController'] = $PSBoundParameters['DomainController']
     }
+
     if ($PSBoundParameters.ContainsKey('Credential'))
     {
         $getParameters['Credential'] = $PSBoundParameters['Credential']
     }
+
     $targetResource = Get-TargetResource @getParameters
 
     # Add common name, ensure and enabled as they may not be explicitly passed
@@ -2304,7 +2074,7 @@ function Get-MD5HashString
         $md5 = [System.Security.Cryptography.MD5]::Create()
         $hashBytes = $md5.ComputeHash($Bytes)
 
-        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-','')
+        $md5ReturnValue = [System.BitConverter]::ToString($hashBytes).Replace('-', '')
     }
 
     return $md5ReturnValue

--- a/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -928,12 +928,10 @@ function Test-TargetResource
     {
         $getParameters['DomainController'] = $PSBoundParameters['DomainController']
     }
-
     if ($PSBoundParameters.ContainsKey('Credential'))
     {
         $getParameters['Credential'] = $PSBoundParameters['Credential']
     }
-
     $targetResource = Get-TargetResource @getParameters
 
     $isCompliant = $true
@@ -1596,12 +1594,10 @@ function Set-TargetResource
     {
         $getParameters['DomainController'] = $PSBoundParameters['DomainController']
     }
-
     if ($PSBoundParameters.ContainsKey('Credential'))
     {
         $getParameters['Credential'] = $PSBoundParameters['Credential']
     }
-
     $targetResource = Get-TargetResource @getParameters
 
     # Add common name, ensure and enabled as they may not be explicitly passed

--- a/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
+++ b/DSCResources/MSFT_ADUser/MSFT_ADUser.psm1
@@ -626,7 +626,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $ensure = 'Present',
+        $Ensure = 'Present',
 
         [Parameter()]
         [ValidateNotNull()]
@@ -921,24 +921,26 @@ function Test-TargetResource
 
     $getParameters = @{ }
 
-    $getParameters['DomainName'] = $PSBoundParameters['DomainName']
-    $getParameters['UserName'] = $PSBoundParameters['UserName']
+    $getParameters = @{
+        DomainName = $DomainName
+        UserName   = $UserName
+    }
 
     if ($PSBoundParameters.ContainsKey('DomainController'))
     {
-        $getParameters['DomainController'] = $PSBoundParameters['DomainController']
+        $getParameters['DomainController'] = $DomainController
     }
 
     if ($PSBoundParameters.ContainsKey('Credential'))
     {
-        $getParameters['Credential'] = $PSBoundParameters['Credential']
+        $getParameters['Credential'] = $Credential
     }
 
     $targetResource = Get-TargetResource @getParameters
 
     $isCompliant = $true
 
-    if ($ensure -eq 'Absent')
+    if ($Ensure -eq 'Absent')
     {
         if ($targetResource.Ensure -eq 'Present')
         {
@@ -948,8 +950,8 @@ function Test-TargetResource
     }
     else
     {
-        # Add common name, ensure and enabled as they may not be explicitly passed and we want to enumerate them
-        $PSBoundParameters['Ensure'] = $ensure
+        # Add common name, Ensure and enabled as they may not be explicitly passed and we want to enumerate them
+        $PSBoundParameters['Ensure'] = $Ensure
         $PSBoundParameters['Enabled'] = $Enabled
 
         foreach ($parameter in $PSBoundParameters.Keys)
@@ -1293,7 +1295,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $ensure = 'Present',
+        $Ensure = 'Present',
 
         [Parameter()]
         [ValidateNotNull()]
@@ -1589,27 +1591,29 @@ function Set-TargetResource
 
     $getParameters = @{ }
 
-    $getParameters['DomainName'] = $PSBoundParameters['DomainName']
-    $getParameters['UserName'] = $PSBoundParameters['UserName']
+    $getParameters = @{
+        DomainName = $DomainName
+        UserName   = $UserName
+    }
 
     if ($PSBoundParameters.ContainsKey('DomainController'))
     {
-        $getParameters['DomainController'] = $PSBoundParameters['DomainController']
+        $getParameters['DomainController'] = $DomainController
     }
 
     if ($PSBoundParameters.ContainsKey('Credential'))
     {
-        $getParameters['Credential'] = $PSBoundParameters['Credential']
+        $getParameters['Credential'] = $Credential
     }
 
     $targetResource = Get-TargetResource @getParameters
 
-    # Add common name, ensure and enabled as they may not be explicitly passed
-    $PSBoundParameters['Ensure'] = $ensure
+    # Add common name, Ensure and enabled as they may not be explicitly passed
+    $PSBoundParameters['Ensure'] = $Ensure
     $PSBoundParameters['Enabled'] = $Enabled
     $newADUser = $false
 
-    if ($ensure -eq 'Present')
+    if ($Ensure -eq 'Present')
     {
         if ($targetResource.Ensure -eq 'Absent')
         {
@@ -1847,7 +1851,7 @@ function Set-TargetResource
             Rename-ADObject @renameAdObjectParameters -NewName $PSBoundParameters.CommonName
         }
     }
-    elseif (($ensure -eq 'Absent') -and ($targetResource.Ensure -eq 'Present'))
+    elseif (($Ensure -eq 'Absent') -and ($targetResource.Ensure -eq 'Present'))
     {
         # User exists and needs removing
         Write-Verbose ($script:localizedData.RemovingADUser -f $UserName)

--- a/Tests/Unit/MSFT_ADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_ADUser.Tests.ps1
@@ -297,6 +297,9 @@ try
 
         #region Function Test-TargetResource
         Describe 'ADUser\Test-TargetResource' {
+            BeforeAll {
+                $testPresentParams['Ensure'] = 'Present'
+            }
             It "Passes when user account does not exist and 'Ensure' is 'Absent'" {
                 Mock -CommandName Get-TargetResource -MockWith { return $testAbsentParams }
 

--- a/Tests/Unit/MSFT_ADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_ADUser.Tests.ps1
@@ -297,7 +297,6 @@ try
 
         #region Function Test-TargetResource
         Describe 'ADUser\Test-TargetResource' {
-
             It "Passes when user account does not exist and 'Ensure' is 'Absent'" {
                 Mock -CommandName Get-TargetResource -MockWith { return $testAbsentParams }
 

--- a/Tests/Unit/MSFT_ADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_ADUser.Tests.ps1
@@ -203,13 +203,14 @@ try
         Describe 'ADUser\Get-TargetResource' {
             BeforeAll {
                 Mock -CommandName Assert-Module
-                $testPresentParams.Remove('Ensure')
+                $getTargetResourceParameters = $testPresentParams.Clone()
+                $getTargetResourceParameters.Remove('Ensure')
             }
 
             It "Returns a 'System.Collections.Hashtable' object type" {
                 Mock -CommandName Get-ADUser -MockWith { return [PSCustomObject] $fakeADUser }
 
-                $adUser = Get-TargetResource @testPresentParams
+                $adUser = Get-TargetResource @getTargetResourceParameters
 
                 $adUser -is [System.Collections.Hashtable] | Should -BeTrue
             }
@@ -217,7 +218,7 @@ try
             It "Returns 'Ensure' is 'Present' when user account exists" {
                 Mock -CommandName Get-ADUser -MockWith { return [PSCustomObject] $fakeADUser }
 
-                $adUser = Get-TargetResource @testPresentParams
+                $adUser = Get-TargetResource @getTargetResourceParameters
 
                 $adUser.Ensure | Should -Be 'Present'
             }
@@ -225,7 +226,7 @@ try
             It "Returns 'Ensure' is 'Absent' when user account does not exist" {
                 Mock -CommandName Get-ADUser -MockWith { throw New-Object Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException }
 
-                $adUser = Get-TargetResource @testPresentParams
+                $adUser = Get-TargetResource @getTargetResourceParameters
 
                 $adUser.Ensure | Should -Be 'Absent'
             }
@@ -233,14 +234,14 @@ try
             It "Should throw the correct exception when Get-ADUser returns an unknown error" {
                 Mock -CommandName Get-ADUser -MockWith { throw }
 
-                $expectedError = $script:localizedData.RetrievingADUserError -f $testPresentParams.UserName, $testPresentParams.DomainName
-                { Get-TargetResource @testPresentParams } | Should -Throw $expectedError
+                $expectedError = $script:localizedData.RetrievingADUserError -f $getTargetResourceParameters.UserName, $getTargetResourceParameters.DomainName
+                { Get-TargetResource @getTargetResourceParameters } | Should -Throw $expectedError
             }
 
             It "Calls 'Get-ADUser' with 'Server' parameter when 'DomainController' specified" {
                 Mock -CommandName Get-ADUser -ParameterFilter { $Server -eq $testDomainController } -MockWith { return [PSCustomObject] $fakeADUser }
 
-                Get-TargetResource @testPresentParams -DomainController $testDomainController
+                Get-TargetResource @getTargetResourceParameters -DomainController $testDomainController
 
                 Assert-MockCalled -CommandName Get-ADUser -ParameterFilter { $Server -eq $testDomainController } -Scope It
             }
@@ -248,14 +249,14 @@ try
             It "Calls 'Get-ADUser' with 'Credential' parameter when 'Credential' specified" {
                 Mock -CommandName Get-ADUser -ParameterFilter { $Credential -eq $testCredential } -MockWith { return [PSCustomObject] $fakeADUser }
 
-                Get-TargetResource @testPresentParams -Credential $testCredential
+                Get-TargetResource @getTargetResourceParameters -Credential $testCredential
 
                 Assert-MockCalled -CommandName Get-ADUser -ParameterFilter { $Credential -eq $testCredential } -Scope It
             }
             It "Should return the correct value for an Array property" {
                 Mock -CommandName Get-ADUser -MockWith { return [PSCustomObject] $fakeADUser }
 
-                $adUser = Get-TargetResource @testPresentParams
+                $adUser = Get-TargetResource @getTargetResourceParameters
                 $adUser.ServicePrincipalNames | Should -Be $fakeADUser.ServicePrincipalName
             }
 
@@ -264,7 +265,7 @@ try
                 $mockADUser['pwdLastSet'] = 0
                 Mock -CommandName Get-ADUser -MockWith { return [PSCustomObject] $mockADUser }
 
-                $adUser = Get-TargetResource @testPresentParams
+                $adUser = Get-TargetResource @getTargetResourceParameters
                 $adUser.ChangePasswordAtLogon | Should -BeTrue
             }
 
@@ -273,7 +274,7 @@ try
                 $mockADUser['pwdLastSet'] = 12345678
                 Mock -CommandName Get-ADUser -MockWith { return [PSCustomObject] $mockADUser }
 
-                $adUser = Get-TargetResource @testPresentParams
+                $adUser = Get-TargetResource @getTargetResourceParameters
                 $adUser.ChangePasswordAtLogon | Should -BeFalse
             }
 
@@ -287,7 +288,7 @@ try
                     return [PSCustomObject] $mockADUser
                 }
 
-                $adUser = Get-TargetResource @testPresentParams
+                $adUser = Get-TargetResource @getTargetResourceParameters
                 $adUser.ThumbnailPhoto | Should -Be $mockThumbnailPhotoBase64
                 $adUser.ThumbnailPhotoHash | Should -Be $mockThumbnailPhotoHash
             }
@@ -296,9 +297,7 @@ try
 
         #region Function Test-TargetResource
         Describe 'ADUser\Test-TargetResource' {
-            BeforeAll {
-                $testPresentParams['Ensure'] = 'Present'
-            }
+
             It "Passes when user account does not exist and 'Ensure' is 'Absent'" {
                 Mock -CommandName Get-TargetResource -MockWith { return $testAbsentParams }
 

--- a/Tests/Unit/MSFT_ADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_ADUser.Tests.ps1
@@ -297,9 +297,7 @@ try
 
         #region Function Test-TargetResource
         Describe 'ADUser\Test-TargetResource' {
-            BeforeAll {
-                $testPresentParams['Ensure'] = 'Present'
-            }
+
             It "Passes when user account does not exist and 'Ensure' is 'Absent'" {
                 Mock -CommandName Get-TargetResource -MockWith { return $testAbsentParams }
 

--- a/Tests/Unit/MSFT_ADUser.Tests.ps1
+++ b/Tests/Unit/MSFT_ADUser.Tests.ps1
@@ -203,6 +203,7 @@ try
         Describe 'ADUser\Get-TargetResource' {
             BeforeAll {
                 Mock -CommandName Assert-Module
+                $testPresentParams.Remove('Ensure')
             }
 
             It "Returns a 'System.Collections.Hashtable' object type" {
@@ -254,29 +255,25 @@ try
             It "Should return the correct value for an Array property" {
                 Mock -CommandName Get-ADUser -MockWith { return [PSCustomObject] $fakeADUser }
 
-                $adUser = Get-TargetResource @testPresentParams -ServicePrincipalNames ''
+                $adUser = Get-TargetResource @testPresentParams
                 $adUser.ServicePrincipalNames | Should -Be $fakeADUser.ServicePrincipalName
             }
 
             It "Should return the correct value of 'ChangePassswordAtLogon' if it is true" {
                 $mockADUser = $fakeADUser.Clone()
                 $mockADUser['pwdLastSet'] = 0
-                $mockPresentParams = $testPresentParams.Clone()
-                $mockPresentParams['ChangePasswordAtLogon'] = $true
                 Mock -CommandName Get-ADUser -MockWith { return [PSCustomObject] $mockADUser }
 
-                $adUser = Get-TargetResource @mockPresentParams
+                $adUser = Get-TargetResource @testPresentParams
                 $adUser.ChangePasswordAtLogon | Should -BeTrue
             }
 
             It "Should return the correct value of 'ChangePassswordAtLogon' if it is false" {
                 $mockADUser = $fakeADUser.Clone()
                 $mockADUser['pwdLastSet'] = 12345678
-                $mockPresentParams = $testPresentParams.Clone()
-                $mockPresentParams['ChangePasswordAtLogon'] = $true
                 Mock -CommandName Get-ADUser -MockWith { return [PSCustomObject] $mockADUser }
 
-                $adUser = Get-TargetResource @mockPresentParams
+                $adUser = Get-TargetResource @testPresentParams
                 $adUser.ChangePasswordAtLogon | Should -BeFalse
             }
 
@@ -286,13 +283,11 @@ try
                 # This a mock of a real thumbnail-photo (the DSC logo).
                 $mockADUser['ThumbnailPhoto'] = $mockThumbnailPhotoByteArray
 
-                $mockPresentParams = $testPresentParams.Clone()
-
                 Mock -CommandName Get-ADUser -MockWith {
                     return [PSCustomObject] $mockADUser
                 }
 
-                $adUser = Get-TargetResource @mockPresentParams
+                $adUser = Get-TargetResource @testPresentParams
                 $adUser.ThumbnailPhoto | Should -Be $mockThumbnailPhotoBase64
                 $adUser.ThumbnailPhotoHash | Should -Be $mockThumbnailPhotoHash
             }
@@ -301,6 +296,9 @@ try
 
         #region Function Test-TargetResource
         Describe 'ADUser\Test-TargetResource' {
+            BeforeAll {
+                $testPresentParams['Ensure'] = 'Present'
+            }
             It "Passes when user account does not exist and 'Ensure' is 'Absent'" {
                 Mock -CommandName Get-TargetResource -MockWith { return $testAbsentParams }
 


### PR DESCRIPTION
#### Pull Request (PR) description
According to DSC Resource Style Guidelines & Best Practices there should be only mandatory parameters in the Get-TargetResource function.
The unused non-mandatory parameters are removed.

#### This Pull Request (PR) fixes the following issues
- Fixes #293 

#### Task list
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Conceptual help topic added/updated (cultureFolder\about_ResourceName.help.txt).
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/activedirectorydsc/487)
<!-- Reviewable:end -->
