### PR TITLE
Enable Default PSSCript Rules

### DIFF
--- a/.vscode/analyzersettings.psd1
+++ b/.vscode/analyzersettings.psd1
@@ -4,9 +4,9 @@
         cloned. It is automatically clone as soon as any unit or
         integration tests are run.
     #>
-    CustomRulePath = '.\DSCResource.Tests\DscResource.AnalyzerRules'
+    CustomRulePath      = '.\DSCResource.Tests\DscResource.AnalyzerRules'
 
-    IncludeRules   = @(
+    IncludeRules        = @(
         # DSC Resource Kit style guideline rules.
         'PSAvoidDefaultValueForMandatoryParameter',
         'PSAvoidDefaultValueSwitchParameter',
@@ -50,4 +50,6 @@
         #>
         'Measure-*'
     )
+
+    IncludeDefaultRules = $true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     in the `Tests/Unit/Stubs` folder ([issue #245](https://github.com/PowerShell/ActiveDirectoryDsc/issues/245)).
   - Update all unit tests removing all local stub functions in favor of
     the new stub modules.
+  - Enable PSSCriptAnalyzer default rules ([issue #491](https://github.com/PowerShell/ActiveDirectoryDsc/issues/491)).
 - Changes to ActiveDirectoryDsc.Common
   - Updated common helper function `Find-DomainController` with the
     optional parameter `WaitForValidCredentials` which will ignore


### PR DESCRIPTION
#### Pull Request (PR) description
I have noticed that the default rules for PSScriptAnalyzer were not enabled, although a bunch of them are part of IncludeRules array.
Adding following line in analyzersettings.psd1 would enable them:
IncludeDefaultRules = $true
#### This Pull Request (PR) fixes the following issues
- Fixes #491 
#### Task list
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Conceptual help topic added/updated (cultureFolder\about_ResourceName.help.txt).
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/activedirectorydsc/492)
<!-- Reviewable:end -->
